### PR TITLE
Added remotes for XMLRPC

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,4 +18,4 @@ Author: Duncan Temple Lang
 Maintainer: Duncan Temple Lang <duncan@r-project.org>
 License: BSD
 Imports: XMLRPC, methods
-
+Remotes: duncantl/XMLRPC


### PR DESCRIPTION
Still using this package for Wordpress, but I figure adding `XMLRPC` in remotes would help people in the future.